### PR TITLE
fix bugs in ControlSys

### DIFF
--- a/ControlSys/FeedbackLoopResponse.m
+++ b/ControlSys/FeedbackLoopResponse.m
@@ -1,8 +1,8 @@
 % By: Johnathan Machler 
 % Date: 01.23.19
 
-pkg load control
-pkg load symbolic
+% pkg load control
+% pkg load symbolic
 
 G1 = tf([0 4], [0 1]); 
 G2 = tf([0 1],[1 2]); 
@@ -12,5 +12,8 @@ pole(Sys)'
 
 rlocus(Sys); 
 v=[-6 6 -6 6]; axis(v);axis('square');grid on;
+
+[Num,Den] = tfdata(Sys,'v');
 syms s t
-ilaplace(Sys, s, t) % Takes inverse laplace transform of symbolic expression
+Sys_syms = poly2sym(Num,s)/poly2sym(Den,s); % Convert tf to symbolic expression
+ilaplace(Sys_syms, s, t) % Takes inverse laplace transform of symbolic expression

--- a/ControlSys/PI_Controller.m
+++ b/ControlSys/PI_Controller.m
@@ -3,6 +3,6 @@
 
 gc =tf([0.3 5 5],[1 0]);
 gp = tf([1],[0.01 0.11 0.1]);
-ol = series(gc,gp); # Compensator/ Controller in series with plant
+ol = series(gc,gp);  %Compensator/ Controller in series with plant
 step(feedback(ol,1))
 title('PID controller'); 


### PR DESCRIPTION
there was an error using "ilaplace" function in FeedbackLoopResponse file, which relates its input transfer function type. it fixed by writing codes for converting tf to symbolic expression. 
Also, there was an error about comment structure, which fixed by replacing % .